### PR TITLE
limit S3 writer role to k8s-infra-aws-root-account

### DIFF
--- a/terraform/iam/main.tf
+++ b/terraform/iam/main.tf
@@ -33,7 +33,7 @@ resource "aws_iam_role_policy" "registry-k8s-io-s3writer-policy" {
           "s3-object-lambda:*"
         ]
         Effect   = "Allow"
-        Resource = "*"
+        Resource = "arn:aws:s3::266690972299:*"
       },
     ]
   })


### PR DESCRIPTION
Modifies the registry.k8s.io_s3writer IAM role to only allow S3 actions
in the k8s-infra-aws-root-account account (266690972299)

Signed-off-by: Jay Pipes <jaypipes@gmail.com>