### PR TITLE
Add trust relationship with S3 writer role

### DIFF
--- a/terraform/iam/main.tf
+++ b/terraform/iam/main.tf
@@ -9,7 +9,14 @@ resource "aws_iam_role" "registry-k8s-io-s3writer" {
         Action = "sts:AssumeRole"
         Effect = "Allow"
         Principal = {
-          AWS = "768319786644"
+          AWS = "arn:aws:iam::768319786644:root"
+        }
+      },
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::585803375430:user/registry.k8s.io-ci"
         }
       },
     ]


### PR DESCRIPTION
Ensures that the new _k8s-infra-accounts_ accounts IAM role is able to assume role in the _registry.k8s.io_admin_ s3 writer role