### PR TITLE
Restrict s3writer role to R/W objects

### DIFF
--- a/terraform/iam/main.tf
+++ b/terraform/iam/main.tf
@@ -31,8 +31,8 @@ resource "aws_iam_role_policy" "registry-k8s-io-s3writer-policy" {
     Statement = [
       {
         Action = [
-          "s3:*",
-          "s3-object-lambda:*"
+          "s3:*Object",
+          "s3:ListBucket"
         ]
         Effect   = "Allow"
         Resource = "*"


### PR DESCRIPTION
Limits the permissions to what we will continue to use with this role - no need to delete buckets