### PR TITLE
Set max_session_duration to 12h for s3writer role

### DIFF
--- a/terraform/iam/main.tf
+++ b/terraform/iam/main.tf
@@ -22,6 +22,8 @@ resource "aws_iam_role" "registry-k8s-io-s3writer" {
     ]
   })
 
+  max_session_duration = 43200
+
   tags = {
     project = "registry.k8s.io"
   }


### PR DESCRIPTION
Running into several timeout issues, this will mean that STS will generate tokens for use for 12h when switching role to s3writer