### PR TITLE
Add s3admin for bucket management

### DIFF
--- a/terraform/iam/main.tf
+++ b/terraform/iam/main.tf
@@ -1,3 +1,4 @@
+// s3writer for content management
 resource "aws_iam_role" "registry-k8s-io-s3writer" {
   provider = aws.registry-k8s-io
 
@@ -43,6 +44,59 @@ resource "aws_iam_role_policy" "registry-k8s-io-s3writer-policy" {
           "s3:ListAllMyBuckets",
           "s3:*Object",
           "s3:ListBucket"
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+// s3admin for bucket management
+resource "aws_iam_role" "registry-k8s-io-s3admin" {
+  provider = aws.registry-k8s-io
+
+  name = "registry.k8s.io_s3admin"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::768319786644:root"
+        }
+      },
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::585803375430:user/registry.k8s.io-ci"
+        }
+      },
+    ]
+  })
+
+  max_session_duration = 43200
+
+  tags = {
+    project = "registry.k8s.io"
+  }
+}
+
+resource "aws_iam_role_policy" "registry-k8s-io-s3admin-policy" {
+  provider = aws.registry-k8s-io
+
+  name = "registry.k8s.io_s3admin_policy"
+  role = aws_iam_role.registry-k8s-io-s3admin.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "s3:*",
+          "s3-object-lambda:*"
         ]
         Effect   = "Allow"
         Resource = "*"


### PR DESCRIPTION
The current perms for s3writer only allow for content/object management.
Addresses the need to continue updating buckets.

Related: https://github.com/kubernetes/k8s.io/issues/3935