### PR TITLE
Allow batchoperations to assume role for replication

### DIFF
--- a/terraform/iam/main.tf
+++ b/terraform/iam/main.tf
@@ -74,6 +74,13 @@ resource "aws_iam_role" "registry-k8s-io-s3admin" {
           AWS = "arn:aws:iam::585803375430:user/registry.k8s.io-ci"
         }
       },
+      {
+        Action = "sts:AssumeRole",
+        Effect = "Allow",
+        Principal = {
+          Service = "batchoperations.s3.amazonaws.com"
+        },
+      },
     ]
   })
 


### PR DESCRIPTION
registry.k8s.io bucket replication requires use of the _registry.k8s.io_s3admin_ policy through the role of the same name.
Using s3 batch operations, the buckets are able to be synced for _sig-k8s-infra_.
Updates the policy to allow for such access.