### PR TITLE
Add permissions for registry.k8s.io-ci user to sts assume role

### DIFF
--- a/terraform/iam/main.tf
+++ b/terraform/iam/main.tf
@@ -111,3 +111,40 @@ resource "aws_iam_role_policy" "registry-k8s-io-s3admin-policy" {
     ]
   })
 }
+
+resource "aws_iam_policy" "sts-allow-registry-k8s-io-s3writer" {
+  provider = aws.k8s-infra-accounts
+
+  name = "sts-allow-registry-k8s-io-s3writer"
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Sid" : "CallSTSAssumeRole",
+        "Effect" : "Allow",
+        "Action" : "sts:AssumeRole",
+        "Resource" : "arn:aws:iam::513428760722:role/registry.k8s.io_s3writer"
+      },
+      {
+        "Sid" : "GetTokens",
+        "Effect" : "Allow",
+        "Action" : [
+          "sts:GetSessionToken",
+          "sts:GetAccessKeyInfo",
+          "sts:GetCallerIdentity",
+          "sts:GetServiceBearerToken"
+        ],
+        "Resource" : "*"
+      }
+    ]
+  })
+}
+resource "aws_iam_user" "registry-k8s-io-ci" {
+  provider = aws.k8s-infra-accounts
+  name     = "registry.k8s.io-ci"
+}
+resource "aws_iam_user_policy_attachment" "sts-allow-registry-k8s-io-s3writer" {
+  provider   = aws.k8s-infra-accounts
+  user       = aws_iam_user.registry-k8s-io-ci.name
+  policy_arn = aws_iam_policy.sts-allow-registry-k8s-io-s3writer.arn
+}

--- a/terraform/iam/providers.tf
+++ b/terraform/iam/providers.tf
@@ -29,3 +29,16 @@ provider "aws" {
     role_arn = "arn:aws:iam::513428760722:role/OrganizationAccountAccessRole"
   }
 }
+
+provider "aws" {
+  alias = "k8s-infra-accounts"
+
+  region = "us-west-1"
+
+  # Jay, Hippie and Caleb are cool
+  assume_role {
+    # deleting this role causes bad things. You just really don't want this. Count this as a WARNING!
+    # also! the account (513428760722) is CNCF/Kubernetes/registry.k8s.io/registry.k8s.io_admin / k8s-infra-aws-registry-k8s-io-admin@kubernetes.io
+    role_arn = "arn:aws:iam::585803375430:role/OrganizationAccountAccessRole"
+  }
+}


### PR DESCRIPTION
Adds the missing permissions for the _registry.k8s.io-ci_ IAM user in 585803375430 (_k8s-infra-accounts_) to use STS assume role.