### PR TITLE
Update s3admin role

### DIFF
--- a/terraform/iam/main.tf
+++ b/terraform/iam/main.tf
@@ -68,13 +68,6 @@ resource "aws_iam_role" "registry-k8s-io-s3admin" {
         }
       },
       {
-        Action = "sts:AssumeRole"
-        Effect = "Allow"
-        Principal = {
-          AWS = "arn:aws:iam::585803375430:user/registry.k8s.io-ci"
-        }
-      },
-      {
         Action = "sts:AssumeRole",
         Effect = "Allow",
         Principal = {


### PR DESCRIPTION
s3admin doesn't have a trust relationship with _arn:aws:iam::585803375430:user/registry.k8s.io-ci_, in anycase and should not. removes the onesided tie for the trust relationship.