### PR TITLE
Add replication policy allowance to s3writer

### DIFF
--- a/terraform/iam/main.tf
+++ b/terraform/iam/main.tf
@@ -67,9 +67,15 @@ resource "aws_iam_role_policy" "registry-k8s-io-s3writer-policy" {
     Statement = [
       {
         Action = [
-          "s3:ListAllMyBuckets",
           "s3:*Object",
-          "s3:ListBucket"
+          "s3:GetObjectVersionAcl",
+          "s3:GetObjectVersionForReplication",
+          "s3:GetObjectVersionTagging",
+          "s3:GetReplicationConfiguration",
+          "s3:ListAllMyBuckets",
+          "s3:ListBucket",
+          "s3:ReplicateObject",
+          "s3:ReplicateTags"
         ]
         Effect   = "Allow"
         Resource = "*"


### PR DESCRIPTION
Ensures that the s3writer policy has access to the right actions for s3 object replication.