### PR TITLE
Add PutReplicationConfiguration to s3writer role

### DIFF
--- a/terraform/iam/main.tf
+++ b/terraform/iam/main.tf
@@ -74,6 +74,7 @@ resource "aws_iam_role_policy" "registry-k8s-io-s3writer-policy" {
           "s3:GetReplicationConfiguration",
           "s3:ListAllMyBuckets",
           "s3:ListBucket",
+          "s3:PutReplicationConfiguration",
           "s3:ReplicateObject",
           "s3:ReplicateTags"
         ]


### PR DESCRIPTION
When running `TF_LOG=debug terraform apply -var prefix=prod-` in _kubernetes/k8s.io/infra/aws/terraform/registry.k8s.io_, I'm seeing the following error
```
Validate Response s3/PutBucketReplication failed, attempt 0/25, error AccessDenied: Access Denied
```